### PR TITLE
(update) changes tsconfig build directory to tsbuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ package-lock.json
 .DS_Store
 build
 out
+tsbuild

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "index.tsx",
   "scripts": {
     "compile": "tsc -p ./",
-    "start": "tsc -p ./ && node build/server/server.js",
+    "start": "tsc -p ./ && node tsbuild/server/server.js",
     "build": "NODE_ENV=production webpack",
-    "dev": "NODE_ENV=development concurrently \"nodemon build/server/server.js\" \"webpack-dev-server --open --hot\"",
+    "dev": "NODE_ENV=development tsc -p ./ && nodemon tsbuild/server/server.js & webpack-dev-server --open --hot",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es6",
-    "outDir": "./build/",
+    "outDir": "./tsbuild/",
     "lib": ["es6", "dom"],
     "sourceMap": true,
     "rootDirs": ["client", "public", "server"],


### PR DESCRIPTION
Co-authored-by: Jesus <jmodestov@gmail.com>
Co-authored-by: Ronnie <ronniemail20@gmail.com>
Co-authored-by: Julie <jpinchak@gmail.com>
Co-authored-by: Sanjay <sanjaylavingia@gmail.com>

## Types of changes

<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->

- [x] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to **not** work as expected)

## Purpose

<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
Both webpack and tsconfig were exporting to a 'Build' directory.

## Approach

<!--- How does your change address the problem? -->
We changed tsconfig to export to a 'tsBuild' directory.
